### PR TITLE
Fix TrustProxies middleware ignoring TRUSTED_PROXY env var

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -25,4 +25,12 @@ class TrustProxies extends Middleware
         Request::HEADER_X_FORWARDED_PORT |
         Request::HEADER_X_FORWARDED_PROTO |
         Request::HEADER_X_FORWARDED_AWS_ELB;
+
+    /**
+     * Bootstrap the trusted proxies from config.
+     */
+    public function __construct()
+    {
+        $this->proxies = config('trustedproxy.proxies');
+    }
 }


### PR DESCRIPTION
## Summary

- The `config/trustedproxy.php` reads the `TRUSTED_PROXY` environment variable, but the `TrustProxies` middleware never uses the config value — `$proxies` is left as `null`
- This means Laravel ignores `X-Forwarded-*` headers even when `TRUSTED_PROXY` is set, breaking URL generation behind reverse proxies (nginx, Traefik, etc.)
- Wires the middleware constructor to read from `config('trustedproxy.proxies')` so that setting `TRUSTED_PROXY=*` in `.env` correctly trusts all proxies

## Steps to reproduce

1. Deploy behind a reverse proxy (e.g. nginx with SSL termination)
2. Set `TRUSTED_PROXY=*` in `.env`
3. Access the app — Laravel generates `http://` URLs instead of `https://`, ignoring `X-Forwarded-Proto`

## Test plan

- [ ] Set `TRUSTED_PROXY=*` in `.env` and verify `X-Forwarded-Proto` is respected
- [ ] Verify `$request->ip()` returns the real client IP, not the proxy IP
- [ ] Verify URL generation uses the correct scheme and port behind a reverse proxy
- [ ] Verify default behaviour (no `TRUSTED_PROXY` set) remains unchanged